### PR TITLE
DeepCompare(...):  memoize array lengths

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,10 @@ $CLIRoot = Join-Path $RepoRoot 'cli'
 $DotNetExe = Join-Path $CLIRoot 'dotnet.exe'
 $NuGetExe = Join-Path $RepoRoot '.nuget\nuget.exe'
 
-rm -r $ArtifactsDir -Force | Out-Null
+if (Test-Path $ArtifactsDir)
+{
+    rm -r $ArtifactsDir -Force | Out-Null
+}
 
 New-Item -ItemType Directory -Force -Path $CLIRoot | Out-Null
 New-Item -ItemType Directory -Force -Path $ArtifactsDir | Out-Null

--- a/src/json-ld.net/Core/JsonLdUtils.cs
+++ b/src/json-ld.net/Core/JsonLdUtils.cs
@@ -88,14 +88,16 @@ namespace JsonLD.Core
                         {
                             JArray l1 = (JArray)v1;
                             JArray l2 = (JArray)v2;
-                            if (l1.Count != l2.Count)
+                            var l1Count = l1.Count;
+                            var l2Count = l2.Count;
+                            if (l1Count != l2Count)
                             {
                                 return false;
                             }
                             // used to mark members of l2 that we have already matched to avoid
                             // matching the same item twice for lists that have duplicates
-                            bool[] alreadyMatched = new bool[l2.Count];
-                            for (int i = 0; i < l1.Count; i++)
+                            bool[] alreadyMatched = new bool[l2Count];
+                            for (int i = 0; i < l1Count; i++)
                             {
                                 JToken o1 = l1[i];
                                 bool gotmatch = false;
@@ -105,7 +107,7 @@ namespace JsonLD.Core
                                 }
                                 else
                                 {
-                                    for (int j = 0; j < l2.Count; j++)
+                                    for (int j = 0; j < l2Count; j++)
                                     {
                                         if (!alreadyMatched[j] && DeepCompare(o1, l2[j], listOrderMatters))
                                         {


### PR DESCRIPTION
Resolve https://github.com/linked-data-dotnet/json-ld.net/issues/29.

Using the repro in the issue before and after this change, I see an ~82% improvement.

| Trial | Before (seconds) | After (seconds) |
| --- | --- | --- |
| 1 | 4.7120547 | 0.8858446 |
| 2 | 4.4700995 | 0.7774562 |
| 3 | 4.7587833 | 0.718364 |
| 4 | 4.4111438 | 0.7194454 |
| 5 | 4.6068476 | 0.7290612 |
| 6 | 4.4516934 | 0.9075534 |
| 7 | 4.5342458 | 1.0242339 |
| 8 | 4.9928839 | 0.7582783 |
| 9 | 4.8472956 | 0.7843428 |
| 10 | 4.6274842 | 0.7340139 |
| Average | 4.64125318 | 0.80385937 |

Also fixing an issue in build.ps1 where an error would be reported if a directory did not exist when calling `Remove-Item` (`rm`) on it.

All tests pass.