### PR TITLE
GenerateNodeMap(...):  improve framing performance with large sets of objects

### DIFF
--- a/src/json-ld.net/Core/JsonLdApi.cs
+++ b/src/json-ld.net/Core/JsonLdApi.cs
@@ -1073,13 +1073,33 @@ namespace JsonLD.Core
         internal virtual void GenerateNodeMap(JToken element, JObject
              nodeMap, string activeGraph, JToken activeSubject, string activeProperty, JObject list)
         {
+            GenerateNodeMap(element, nodeMap, activeGraph, activeSubject, activeProperty, list, skipSetContainsCheck: false);
+        }
+
+        private void GenerateNodeMap(JToken element, JObject nodeMap,
+            string activeGraph, JToken activeSubject, string activeProperty, JObject list, bool skipSetContainsCheck)
+        {
             // 1)
             if (element is JArray)
             {
+                JsonLdSet set = null;
+
+                if (list == null)
+                {
+                    set = new JsonLdSet();
+                }
+
                 // 1.1)
                 foreach (JToken item in (JArray)element)
                 {
-                    GenerateNodeMap(item, nodeMap, activeGraph, activeSubject, activeProperty, list);
+                    skipSetContainsCheck = false;
+
+                    if (set != null)
+                    {
+                        skipSetContainsCheck = set.Add(item);
+                    }
+
+                    GenerateNodeMap(item, nodeMap, activeGraph, activeSubject, activeProperty, list, skipSetContainsCheck);
                 }
                 return;
             }
@@ -1204,7 +1224,7 @@ namespace JsonLD.Core
                             if (list == null)
                             {
                                 // 6.6.2.1+2)
-                                JsonLdUtils.MergeValue(node, activeProperty, reference);
+                                JsonLdUtils.MergeValue(node, activeProperty, reference, skipSetContainsCheck);
                             }
                             else
                             {

--- a/src/json-ld.net/Core/JsonLdSet.cs
+++ b/src/json-ld.net/Core/JsonLdSet.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace JsonLD.Core
+{
+    internal sealed class JsonLdSet
+    {
+        private readonly Lazy<HashSet<string>> _objects;
+
+        internal JsonLdSet()
+        {
+            _objects = new Lazy<HashSet<string>>(() => new HashSet<string>(StringComparer.Ordinal));
+        }
+
+        internal bool Add(JToken token)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (token is JObject)
+            {
+                var id = token["@id"];
+
+                return id != null && _objects.Value.Add(id.Value<string>());
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/json-ld.net/Core/JsonLdUtils.cs
+++ b/src/json-ld.net/Core/JsonLdUtils.cs
@@ -148,8 +148,12 @@ namespace JsonLD.Core
             return false;
         }
 
-        internal static void MergeValue(JObject obj, string key, JToken
-             value)
+        internal static void MergeValue(JObject obj, string key, JToken value)
+        {
+            MergeValue(obj, key, value, skipSetContainsCheck: false);
+        }
+
+        internal static void MergeValue(JObject obj, string key, JToken value, bool skipSetContainsCheck)
         {
             if (obj == null)
             {
@@ -161,8 +165,10 @@ namespace JsonLD.Core
                 values = new JArray();
                 obj[key] = values;
             }
-            if ("@list".Equals(key) || (value is JObject && ((IDictionary<string, JToken>
-                )value).ContainsKey("@list")) || !DeepContains(values, (JToken)value))
+            if (skipSetContainsCheck ||
+                "@list".Equals(key) ||
+                (value is JObject && ((IDictionary<string, JToken>)value).ContainsKey("@list")) ||
+                !DeepContains(values, (JToken)value))
             {
                 values.Add(value);
             }


### PR DESCRIPTION
Resolve https://github.com/linked-data-dotnet/json-ld.net/issues/31.

Using the repro in the issue before and after this change, I see an ~97% improvement.

| Trial | Before | After |
| --- | --- | --- |
| 1 | 505.8915237 | 13.2601851 |
| 2 | 508.9117335 | 11.458 |
| 3 | 545.5377558 | 12.084075 |
| 4 | 582.9262411 | 10.1112375 |
| 5 | 512.2979849 | 13.1105859 |
| 6 | 505.554008 | 11.7665342 |
| 7 | 501.6279932 | 10.7252669 |
| 8 | 504.7128402 | 10.1413444 |
| 9 | 505.5059026 | 10.7213306 |
| 10 | 500.5442 | 13.1355745 |
| Average | 517.3510183 | 11.65141341 |

All tests pass.