### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           dotnet pack \
             --include-source \
+            --configuration Release \
             --no-build \
             --no-restore \
             -p:PackageVersion="${{ steps.gitversion.outputs.fullSemVer }}" \

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Test
         run: |
           dotnet test \
-            . \
             --configuration Release \
             --no-build \
             --no-restore \

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           dotnet-version: 2.1.401
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Install dependencies
         run: dotnet restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  gitversion:
+  build:
     runs-on: ubuntu-latest
 
     outputs:
@@ -25,14 +25,7 @@ jobs:
       - id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.3
 
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 2.1.401
 
@@ -44,29 +37,11 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
           restore-keys: ${{ runner.os }}-nuget-
 
-      - name: Install dependencies
-        run: dotnet restore
+      - run: dotnet restore
 
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
+      - run: dotnet build --configuration Release --no-restore
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: .
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: .
-
-      - name: Test
-        run: |
+      - run: |
           dotnet test \
             --configuration Release \
             --no-build \
@@ -80,28 +55,13 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-  nuget-pack:
-    runs-on: ubuntu-latest
-    needs: [build, gitversion]
-
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: .
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.401
-
       - name: NuGet Pack
         run: |
           dotnet pack \
             --include-source \
             --no-build \
             --no-restore \
-            -p:PackageVersion="${{ needs.gitversion.outputs.fullSemVer }}" \
+            -p:PackageVersion="${{ steps.gitversion.outputs.fullSemVer }}" \
             src/json-ld.net/json-ld.net.csproj \
             --output nugets/
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,6 +37,8 @@ jobs:
           dotnet-version: 2.1.401
 
       - uses: actions/cache@v2
+        env:
+          NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,7 @@ name: dotnet
 on:
   push:
     branches: [master]
+    tags: ["*"]
   pull_request:
     branches: [master]
 
@@ -18,12 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gittools/actions/gitversion/setup@v0.9.3
+      - uses: gittools/actions/gitversion/setup@v0.9.4
         with:
           versionSpec: "5.x"
 
       - id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.3
+        uses: gittools/actions/gitversion/execute@v0.9.4
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -55,8 +56,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-      - name: NuGet Pack
-        run: |
+      - run: |
           dotnet pack \
             --include-source \
             --configuration Release \
@@ -64,9 +64,66 @@ jobs:
             --no-restore \
             -p:PackageVersion="${{ steps.gitversion.outputs.fullSemVer }}" \
             src/json-ld.net/json-ld.net.csproj \
-            --output nugets/
+            --output ${{ github.workspace }}/nugets/
 
       - uses: actions/upload-artifact@v2
         with:
           name: nugets
           path: nugets
+
+  nuget-push-dev:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') != true
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: nugets
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1
+          source-url: https://nuget.pkg.github.com/linked-data-dotnet/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: dotnet nuget push "*.nupkg" --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
+
+  nuget-push-prod:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: nugets
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.401
+          source-url: https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+
+      - run: dotnet nuget push nugets/*.nupkg --skip-duplicate
+
+  release-artifacts:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: nugets
+
+      - name: Upload to stable release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: nugets
+          asset_name: json-ld.net
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,22 +73,25 @@ jobs:
 
   nuget-push-dev:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') != true
+    if: github.ref == 'refs/heads/master'
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v2
+      - name: download artifact
+        uses: actions/download-artifact@v2
         with:
           name: nugets
 
-      - uses: actions/setup-dotnet@v1
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1
           source-url: https://nuget.pkg.github.com/linked-data-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: dotnet nuget push "*.nupkg" --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
+      - name: nuget push
+        run: dotnet nuget push "*.nupkg" --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
 
   nuget-push-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,24 @@ on:
     branches: [master]
 
 jobs:
+  gitversion:
+    runs-on: ubuntu-latest
+
+    outputs:
+      fullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: gittools/actions/gitversion/setup@v0.9.3
+        with:
+          versionSpec: "5.x"
+
+      - id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.3
+
   build:
     runs-on: ubuntu-latest
 
@@ -45,8 +63,6 @@ jobs:
           name: build
           path: .
 
-      - run: ls -la
-
       - name: Test
         run: |
           dotnet test \
@@ -62,3 +78,33 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
+
+  nuget-pack:
+    runs-on: ubuntu-latest
+    needs: [build, gitversion]
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: .
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.401
+
+      - name: NuGet Pack
+        run: |
+          dotnet pack \
+            --include-source \
+            --no-build \
+            --no-restore \
+            -p:PackageVersion="${{ needs.gitversion.outputs.fullSemVer }}" \
+            src/json-ld.net/json-ld.net.csproj \
+            --output nugets/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nugets
+          path: nugets

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,9 +40,12 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v2
         with:
           name: build
+          path: .
+
+      - run: ls -la
 
       - name: Test
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,32 +2,38 @@ name: dotnet
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.1.401
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.401
 
-    - name: Install dependencies
-      run: dotnet restore
+      - name: Install dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
-    - name: Test
-      run: dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[JsonLD.Test*]*"
+      - name: Test
+        run: |
+          dotnet test \
+            . \
+            --configuration Release \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:Exclude="[JsonLD.Test*]*"
 
-    - name: Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      - name: Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,11 +30,27 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: build
+
       - name: Test
         run: |
           dotnet test \
             . \
             --configuration Release \
+            --no-build \
+            --no-restore \
             -p:CollectCoverage=true \
             -p:CoverletOutputFormat=opencover \
             -p:Exclude="[JsonLD.Test*]*"

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -17,6 +17,7 @@ Implements the W3C JSON-LD 1.0 standard.</Description>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <RepositoryUrl>https://github.com/linked-data-dotnet/json-ld.net</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />


### PR DESCRIPTION
This adds a release workflow that will add to the existing test workflow, which in total should make the CI/CD pipeline look like this:

1. Pull requests are tested with various tools and reported with GitHub Checks so it's easy to see the condition of a PR.
2. All pull requests need to be reviewd by a code owner (see #61).
3. When a PR has all green checks and an approved review, it will be merged to `master`.
4. All commits to `master` will invoke the release pipeline to release a pre-release package to the GitHub Package Registry.
5. Once we are happy with the state of `master` a maintainer creates a new GitHub Release versioned according to [SemVer 2.0](https://semver.org/).
6. The release will also create a tag, which will invoke a new release workflow, this time for a stable release to NuGet.org.

Thoughts, comments and general feedback is welcome.