### PR TITLE
Reduce netstandard version to 1.1

### DIFF
--- a/src/json-ld.net/Core/Context.cs
+++ b/src/json-ld.net/Core/Context.cs
@@ -14,9 +14,6 @@ namespace JsonLD.Core
 	/// <author>tristan</author>
 	//[System.Serializable]
 	public class Context : JObject
-#if !PORTABLE && !IS_CORECLR
-        , ICloneable
-#endif
     {
         private JsonLdOptions options;
 

--- a/src/json-ld.net/Core/JsonLdApi.cs
+++ b/src/json-ld.net/Core/JsonLdApi.cs
@@ -2196,7 +2196,6 @@ namespace JsonLD.Core
         /// <exception cref="JsonLD.Core.JsonLdError"></exception>
         public virtual object Normalize(RDFDataset dataset)
         {
-#if !PORTABLE
             // create quads and map bnodes to their associated quads
             IList<RDFDataset.Quad> quads = new List<RDFDataset.Quad>();
             IDictionary<string,IDictionary<string,object>> bnodes = new Dictionary<string,IDictionary<string,object>>();
@@ -2247,9 +2246,6 @@ namespace JsonLD.Core
             NormalizeUtils normalizeUtils = new NormalizeUtils(quads, bnodes, new UniqueNamer
                 ("_:c14n"), opts);
             return normalizeUtils.HashBlankNodes(bnodes.Keys);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
     }
 }

--- a/src/json-ld.net/Core/JsonLdProcessor.cs
+++ b/src/json-ld.net/Core/JsonLdProcessor.cs
@@ -487,24 +487,16 @@ namespace JsonLD.Core
         /// <exception cref="JsonLDNet.Core.JsonLdError"></exception>
         public static object Normalize(JToken input, JsonLdOptions options)
         {
-#if !PORTABLE
             JsonLdOptions opts = options.Clone();
             opts.format = null;
             RDFDataset dataset = (RDFDataset)ToRDF(input, opts);
             return new JsonLdApi(options).Normalize(dataset);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <exception cref="JsonLD.Core.JsonLdError"></exception>
         public static object Normalize(JToken input)
         {
-#if !PORTABLE
             return Normalize(input, new JsonLdOptions(string.Empty));
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
     }
 }

--- a/src/json-ld.net/Core/NormalizeUtils.cs
+++ b/src/json-ld.net/Core/NormalizeUtils.cs
@@ -29,7 +29,6 @@ namespace JsonLD.Core
         /// <exception cref="JsonLD.Core.JsonLdError"></exception>
         public virtual object HashBlankNodes(IEnumerable<string> unnamed_)
         {
-#if !PORTABLE
             IList<string> unnamed = new List<string>(unnamed_);
             IList<string> nextUnnamed = new List<string>();
             IDictionary<string, IList<string>> duplicates = new Dictionary<string, IList<string
@@ -203,9 +202,6 @@ namespace JsonLD.Core
                     }
                 }
             }
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         private sealed class _IComparer_145 : IComparer<NormalizeUtils.HashResult>
@@ -245,7 +241,6 @@ namespace JsonLD.Core
         /// <param name="callback">(err, result) called once the operation completes.</param>
         private static NormalizeUtils.HashResult HashPaths(string id, IDictionary<string, IDictionary<string, object>> bnodes, UniqueNamer namer, UniqueNamer pathNamer)
         {
-#if !PORTABLE
             MessageDigest md = null;
 
             try
@@ -460,9 +455,6 @@ namespace JsonLD.Core
             {
                 md?.Dispose();
             }
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <summary>Hashes all of the quads about a blank node.</summary>
@@ -500,7 +492,6 @@ namespace JsonLD.Core
         /// <returns></returns>
         private static string Sha1hash(ICollection<string> nquads)
         {
-#if !PORTABLE
             try
             {
                 // create SHA-1 digest
@@ -515,9 +506,6 @@ namespace JsonLD.Core
             {
                 throw;
             }
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // TODO: this is something to optimize

--- a/src/json-ld.net/Util/JavaCompat.cs
+++ b/src/json-ld.net/Util/JavaCompat.cs
@@ -6,10 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-
-#if !PORTABLE
 using System.Security.Cryptography;
-#endif
 
 namespace JsonLD
 {
@@ -281,13 +278,7 @@ namespace JsonLD
 
         public string GetPattern()
         {
-#if !PORTABLE && !IS_CORECLR
-            return this.pattern;
-#elif !PORTABLE
             return _rx;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         new public static bool Matches(string val, string rx)
@@ -357,7 +348,6 @@ namespace JsonLD
     }
 
 
-#if !PORTABLE
     internal class MessageDigest : IDisposable
     {
         SHA1 md;
@@ -392,5 +382,4 @@ namespace JsonLD
             md.Dispose();
         }
     }
-#endif
 }

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -5,36 +5,27 @@
 Implements the W3C JSON-LD 1.0 standard.</Description>
     <VersionPrefix>1.0.7</VersionPrefix>
     <Authors>NuGet;linked-data-dotnet</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>json-ld.net</AssemblyName>
     <PackageId>json-ld.net</PackageId>
     <PackageTags>json-ld;jsonld;json;linked-data;rdf;semantic;web</PackageTags>
     <PackageIconUrl>http://json-ld.org/images/json-ld-logo-64.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/linked-data-dotnet/json-ld.net/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/linked-data-dotnet/json-ld.net/master/LICENSE</PackageLicenseUrl>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.1' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <RepositoryUrl>https://github.com/linked-data-dotnet/json-ld.net</RepositoryUrl>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40-client' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'portable45-net45+win8' ">
-    <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -5,7 +5,7 @@
 Implements the W3C JSON-LD 1.0 standard.</Description>
     <VersionPrefix>1.0.7</VersionPrefix>
     <Authors>NuGet;linked-data-dotnet</Authors>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net40</TargetFrameworks>
     <AssemblyName>json-ld.net</AssemblyName>
     <PackageId>json-ld.net</PackageId>
     <PackageTags>json-ld;jsonld;json;linked-data;rdf;semantic;web</PackageTags>
@@ -23,5 +23,10 @@ Implements the W3C JSON-LD 1.0 standard.</Description>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
   </ItemGroup>
 </Project>

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -13,7 +13,6 @@ Implements the W3C JSON-LD 1.0 standard.</Description>
     <PackageProjectUrl>https://github.com/linked-data-dotnet/json-ld.net/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/linked-data-dotnet/json-ld.net/master/LICENSE</PackageLicenseUrl>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.1' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -19,9 +19,6 @@ Implements the W3C JSON-LD 1.0 standard.</Description>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <RepositoryUrl>https://github.com/linked-data-dotnet/json-ld.net</RepositoryUrl>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
**NOTE: I don't know if this is a good idea or not--I just wanted to kick off the conversation.**

I was just experimenting with how low I could get our .NET Standard version.

**There are two commits:**
1. The first one lowers our minimum target platform to `netstandard1.1`, and
1. The second one enables a bunch of previously conditionally compiled code everywhere, since it now seems to be universally supported by all of our platform targets.

The first one doesn't appear to have any downsides. The second is probably safe as well. It loses `ICloneable` on `Context`, but it looks like it was disabled in all of our builds anyway.

**Analysis**
It turns out that all tests pass with zero changes all the way down to `netstandard1.1`. Unfortunately, `netstandard1.0`, is missing `HttpClient`. Given that `netstandard1.0` picks up ZERO additional compatible framework versions, this doesn't seem like a worthwhile tradeoff.

`netstandard1.1` covers us all the way down to .NET Core 1.0 & .NET Framework 4.5. [Best practices recommend targeting `netstandard2.0` as well][1] so that for modern frameworks one doesn't have to restore hundreds of no-op netstandard NuGet packages.

@asbjornu, [you added `netcoreapp2.1`, a couple of years ago.][2] What does that buy us on top of `netstandard1.1;netstandard2.0`?


[1]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#which-net-standard-version-to-target
[2]: https://github.com/linked-data-dotnet/json-ld.net/commit/da813514a774f6e4680280583a9b10c10ce6f196