### PR TITLE
Bump GitVersion action from 0.9.4 to 0.9.7

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gittools/actions/gitversion/setup@v0.9.4
+      - uses: gittools/actions/gitversion/setup@v0.9.7
         with:
           versionSpec: "5.x"
 
       - id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.4
+        uses: gittools/actions/gitversion/execute@v0.9.7
 
       - uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
Bump GitVersion action from 0.9.4 to 0.9.7 to fix the deprecated `::set-env` errors.