### PR TITLE
Rename `master` to `main`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: docker
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
-    branches: [master] 
+    branches: [main]
 
 jobs:
   docker:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gittools/actions/gitversion/setup@v0.9.7
+      - uses: gittools/actions/gitversion/setup@v0.9.9
         with:
-          versionSpec: "5.x"
+          versionSpec: 5.x
 
       - id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
+        uses: gittools/actions/gitversion/execute@v0.9.9
 
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.401
+          dotnet-version: 2.1.815
 
       - uses: actions/cache@v2
         env:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,10 +2,10 @@ name: dotnet
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:
@@ -73,7 +73,7 @@ jobs:
 
   nuget-push-dev:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     needs: build
 
     steps:

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ https://github.com/linked-data-dotnet/json-ld.net
   [coc]:                        https://opensource.microsoft.com/codeofconduct/
   [coc-faq]:                    https://opensource.microsoft.com/codeofconduct/faq/
   [codecov]:                    https://codecov.io/gh/linked-data-dotnet/json-ld.net
-  [codecov-badge]:              https://img.shields.io/codecov/c/github/linked-data-dotnet/json-ld.net/master.svg
+  [codecov-badge]:              https://img.shields.io/codecov/c/github/linked-data-dotnet/json-ld.net/main.svg
 
   [errata]:                     http://www.w3.org/2014/json-ld-errata
 
@@ -707,5 +707,5 @@ https://github.com/linked-data-dotnet/json-ld.net
 
   [sharpen]:                    http://community.versant.com/Projects/html/projectspaces/db4o_product_design/sharpen.html
 
-  [test-runner]:                https://github.com/linked-data-dotnet/json-ld.net/tree/master/test/json-ld.net.tests
+  [test-runner]:                https://github.com/linked-data-dotnet/json-ld.net/tree/main/test/json-ld.net.tests
   [wg-test-suite]:              https://github.com/w3c/json-ld-api/tree/master/tests

--- a/src/json-ld.net/json-ld.net.csproj
+++ b/src/json-ld.net/json-ld.net.csproj
@@ -11,7 +11,7 @@ Implements the W3C JSON-LD 1.0 standard.</Description>
     <PackageTags>json-ld;jsonld;json;linked-data;rdf;semantic;web</PackageTags>
     <PackageIconUrl>http://json-ld.org/images/json-ld-logo-64.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/linked-data-dotnet/json-ld.net/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/linked-data-dotnet/json-ld.net/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/linked-data-dotnet/json-ld.net/main/LICENSE</PackageLicenseUrl>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.1' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
Resolves #102. To update your local branch, do the following:

```shell
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

`master` is already renamed to `main` in the repository settings, this PR is just to update the GitHub Actions workflows and various links to reflect the rename.