### PR TITLE
Exempt planning from becoming stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ exemptLabels:
   - pinned
   - security
   - bug
+  - planning
 
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true


### PR DESCRIPTION
Exempt the `planning` label from becoming stale.