### PR TITLE
Fix tests in 1.x

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: docker
 
 on:
   push:
-    branches: [master]
+    branches: [main, support/*]
     tags: ["*"]
   pull_request:
-    branches: [master] 
+    branches: [main, support/*]
 
 jobs:
   docker:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,10 +2,10 @@ name: dotnet
 
 on:
   push:
-    branches: [main]
+    branches: [main, support/*]
     tags: ["*"]
   pull_request:
-    branches: [main]
+    branches: [main, support/*]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,10 +2,10 @@ name: dotnet
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:
@@ -15,22 +15,22 @@ jobs:
       fullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
 
-      - uses: gittools/actions/gitversion/setup@v0.9.4
+      - uses: gittools/actions/gitversion/setup@v0.9.10
         with:
-          versionSpec: "5.x"
+          versionSpec: 5.x
 
       - id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.4
+        uses: gittools/actions/gitversion/execute@v0.9.10
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 2.1.401
+          dotnet-version: 6.0.x
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v2.1.6
         env:
           NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
         with:
@@ -73,7 +73,7 @@ jobs:
 
   nuget-push-dev:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     needs: build
 
     steps:
@@ -83,9 +83,9 @@ jobs:
           name: nugets
 
       - name: setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 3.1
+          dotnet-version: 6.0.x
           source-url: https://nuget.pkg.github.com/linked-data-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,9 +103,9 @@ jobs:
         with:
           name: nugets
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 2.1.401
+          dotnet-version: 6.0.x
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 #> docker build -t json-ld.net .
 #> docker run --rm json-ld.net dotnet test -v normal
 
-# .NET Core 2.1 on Ubuntu 18.04 LTS
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1-bionic
+# .NET Core 6.0 on Ubuntu 20.04 LTS
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
 
 WORKDIR /App
 

--- a/test/json-ld.net.tests/json-ld.net.tests.csproj
+++ b/test/json-ld.net.tests/json-ld.net.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
This PR cherry-picks the commits from #133 to make the tests and release pipeline in the `support/1.x` branch successful.